### PR TITLE
Update gitdumper.sh with "main" branch name

### DIFF
--- a/Dumper/gitdumper.sh
+++ b/Dumper/gitdumper.sh
@@ -73,15 +73,19 @@ function start_download() {
     QUEUE+=('index')
     QUEUE+=('packed-refs')
     QUEUE+=('refs/heads/master')
+    QUEUE+=('refs/heads/main')
     QUEUE+=('refs/remotes/origin/HEAD')
     QUEUE+=('refs/stash')
     QUEUE+=('logs/HEAD')
     QUEUE+=('logs/refs/heads/master')
+    QUEUE+=('logs/refs/heads/main')
     QUEUE+=('logs/refs/remotes/origin/HEAD')
     QUEUE+=('info/refs')
     QUEUE+=('info/exclude')
     QUEUE+=('/refs/wip/index/refs/heads/master')
+    QUEUE+=('/refs/wip/index/refs/heads/main')
     QUEUE+=('/refs/wip/wtree/refs/heads/master')
+    QUEUE+=('/refs/wip/wtree/refs/heads/main')
 
     #Iterate through QUEUE until there are no more files to download
     while [ ${#QUEUE[*]} -gt 0 ]


### PR DESCRIPTION
The new Git default branch name was changed to main some time ago added URLs to "main" branches not to miss valuable information while dumping git repositories (see:
https://lore.kernel.org/git/pull.656.v4.git.1593009996.gitgitgadget@gmail.com/ or  https://about.gitlab.com/blog/2021/03/10/new-git-default-branch-name/)